### PR TITLE
Add a SynKnifeDetector

### DIFF
--- a/tutorial/0x_knife_example.ipynb
+++ b/tutorial/0x_knife_example.ipynb
@@ -10,16 +10,10 @@
     "import numpy as np\n",
     "import lmfit\n",
     "from bluesky import RunEngine\n",
-    "from ophyd import Device, Signal\n",
-    "from ophyd import Component as Cpt\n",
-    "from ophyd.sim import det, motor1, motor2, noisy_det, SynGauss, SynAxis, SynSignal,EnumSignal\n",
+    "from ophyd.sim import SynGauss, SynAxis, motor1\n",
     "from bluesky.callbacks.best_effort import BestEffortCallback\n",
     "from bluesky.callbacks import LiveFitPlot, LiveFit, LivePlot\n",
-    "from bluesky.callbacks.fitting import PeakStats\n",
-    "from bluesky.callbacks.mpl_plotting import plot_peak_stats\n",
-    "from bluesky.plans import scan, rel_scan, list_scan, grid_scan\n",
-    "from bluesky.plan_stubs import mv\n",
-    "from databroker import Broker\n",
+    "from bluesky.plans import scan\n",
     "from matplotlib.pyplot import ion, subplots\n",
     "from bluesky.utils import install_nb_kicker\n",
     "from scipy.special import erf\n",
@@ -102,9 +96,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "motor = SynAxis(name='motor')\n",
-    "motor.delay = 0.15\n",
-    "detector = SynKnifeDetector('detector', motor, 'motor', center=2, Imax=9, sigma=1)"
+    "motor1.delay = 0.15\n",
+    "detector = SynKnifeDetector('detector', motor1, 'motor1', center=2, Imax=9, sigma=1)"
    ]
   },
   {
@@ -134,12 +127,12 @@
     "init_guess = {'peak': 5, 'sigma': 1.5, 'center': 3}\n",
     "\n",
     "\n",
-    "live_fit = LiveFit(model, 'detector', {'x': 'motor'}, init_guess)\n",
+    "live_fit = LiveFit(model, 'detector', {'x': 'motor1'}, init_guess)\n",
     "live_fit_plot = LiveFitPlot(live_fit, color='r', ax=ax, label='Fit')\n",
-    "live_plot = LivePlot('detector', 'motor', marker='x', linestyle='none', ax=ax, label='Scan')\n",
+    "live_plot = LivePlot('detector', 'motor1', marker='x', linestyle='none', ax=ax, label='Scan')\n",
     "\n",
     "RE(\n",
-    "    scan([detector], motor, -10, 10, num=40),\n",
+    "    scan([detector], motor1, -10, 10, num=40),\n",
     "    [live_fit_plot, live_plot]\n",
     ")"
    ]


### PR DESCRIPTION
This device simulates a detector and a slit. The slit moves in front of the beam, causing the detector signal to increase or decrease depending on how the scan is performed. This is part of the "real" examples section, using a knife-edge example